### PR TITLE
Update main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include <dsp/routing/splitter.h>
 #include <dsp/stream.h>
 #include <dsp/sink/handler_sink.h>
+#include "spdlog/spdlog.h"
 
 #include <gui/widgets/constellation_diagram.h>
 #include <gui/widgets/file_select.h>


### PR DESCRIPTION
To solve the following make errors in manjaro

[ 50%] Building CXX object CMakeFiles/tetra_demodulator.dir/src/main.cpp.o /home/maverick/git/sdrpp-tetra-demodulator/src/main.cpp: In constructor ‘TetraDemodulatorModule::TetraDemodulatorModule(std::string)’: /home/maverick/git/sdrpp-tetra-demodulator/src/main.cpp:79:17: error: ‘spdlog’ has not been declared
   79 |                 spdlog::error("Error opening file for tetra_demodulator output!");
      |                 ^~~~~~
/home/maverick/git/sdrpp-tetra-demodulator/src/main.cpp: In member function ‘virtual void TetraDemodulatorModule::enable()’:
/home/maverick/git/sdrpp-tetra-demodulator/src/main.cpp:119:17: error: ‘spdlog’ has not been declared
  119 |                 spdlog::error("Error opening file for tetra_demodulator output!");
      |                 ^~~~~~
/home/maverick/git/sdrpp-tetra-demodulator/src/main.cpp: In static member function ‘static void TetraDemodulatorModule::menuHandler(void*)’:
/home/maverick/git/sdrpp-tetra-demodulator/src/main.cpp:170:21: error: ‘spdlog’ has not been declared
  170 |                     spdlog::error("Error opening file for tetra_demodulator output!");
      |                     ^~~~~~
make[2]: *** [CMakeFiles/tetra_demodulator.dir/build.make:76: CMakeFiles/tetra_demodulator.dir/src/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/tetra_demodulator.dir/all] Error 2
make: *** [Makefile:136: all] Error 2