### PR TITLE
Add build job for macos

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -115,3 +115,36 @@ jobs:
           with:
               name: tetra_demodulator_win_pdb
               path: build/RelWithDebInfo/tetra_demodulator.pdb
+    build_macos:
+        runs-on: macos-latest
+        steps:
+        - name: Repo checkout
+          uses: actions/checkout@v4
+        - name: Install dependencies
+          run: brew install talloc glfw glew volk fftw
+        - name: Get SDR++ master source
+          run: 'wget https://github.com/AlexandreRouma/SDRPlusPlus/archive/refs/heads/master.tar.gz && tar -zxvf master.tar.gz'
+        - name: Get SDR++ nightly lib
+          uses: dsaltares/fetch-gh-release-asset@master
+          with:
+            repo: 'AlexandreRouma/SDRPlusPlus'
+            version: 'tags/nightly'
+            file: 'sdrpp_macos_arm.zip'
+            token: ${{ secrets.GITHUB_TOKEN }}
+        - name: Unpack SDR++ lib
+          run: 'unzip sdrpp_macos_arm.zip'
+        - name: Download ETSI codec
+          run: |
+            cd src/decoder/etsi_codec-patches
+            sed 's/md5sum/md5 -r/' download_and_patch.sh > download_and_patch_mac.sh
+            chmod +x download_and_patch_mac.sh
+            ./download_and_patch_mac.sh
+        - name: Cmake
+          run: 'mkdir build && cd build && cmake .. -DSDRPP_MODULE_CMAKE="$GITHUB_WORKSPACE/.github/workflows/sdrpp_module_macos.cmake" -DSDRPP_CORE_ROOT="$GITHUB_WORKSPACE/SDRPlusPlus-master/core/src" -DSDRPP_LIB_ROOT="$GITHUB_WORKSPACE/SDR++.app/Contents/Frameworks" -DCMAKE_PREFIX_PATH="/opt/homebrew" -DCMAKE_BUILD_TYPE=Release'
+        - name: Make
+          run: 'cd build && make -j$(sysctl -n hw.ncpu)'
+        - name: Upload library
+          uses: actions/upload-artifact@v4
+          with:
+              name: tetra_demodulator_macos
+              path: ./build/tetra_demodulator.dylib

--- a/.github/workflows/sdrpp_module_macos.cmake
+++ b/.github/workflows/sdrpp_module_macos.cmake
@@ -1,0 +1,65 @@
+# macOS-compatible CMake module for SDR++ plugins
+# Based on .github/workflows/sdrpp_module_hack.cmake with macOS fixes
+
+# Get needed values depending on if this is in-tree or out-of-tree
+if (NOT SDRPP_CORE_ROOT)
+    set(SDRPP_CORE_ROOT "../SDRPlusPlus/core/src")
+endif ()
+if (NOT SDRPP_LIB_ROOT)
+    set(SDRPP_LIB_ROOT "/usr/lib")
+endif ()
+
+# Use CMAKE_CXX_STANDARD instead of compiler flags to avoid applying C++ flags to C files
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Set compiler flags (without -std=c++17 since we use CMAKE_CXX_STANDARD)
+if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(SDRPP_MODULE_COMPILER_FLAGS -g -Og -Wno-unused-command-line-argument)
+    else ()
+        set(SDRPP_MODULE_COMPILER_FLAGS -g -Og)
+    endif ()
+else()
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(SDRPP_MODULE_COMPILER_FLAGS -O3 -Wno-unused-command-line-argument)
+    else ()
+        set(SDRPP_MODULE_COMPILER_FLAGS -O3)
+    endif ()
+endif()
+
+# Created shared lib and link to core
+add_library(${PROJECT_NAME} SHARED ${SRC})
+target_link_libraries(${PROJECT_NAME} PRIVATE "${SDRPP_LIB_ROOT}/libsdrpp_core.dylib")
+
+# Use -undefined dynamic_lookup for macOS to handle symbols resolved at runtime
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    LINK_FLAGS "-undefined dynamic_lookup"
+    PREFIX ""
+    SUFFIX ".dylib"
+)
+
+# Include directories
+# SDRPP_CORE_ROOT points to core/src, so no need for extra /src/
+target_include_directories(${PROJECT_NAME} PRIVATE
+    "${SDRPP_CORE_ROOT}/"
+    "${SDRPP_CORE_ROOT}/imgui/"
+)
+
+# Homebrew include paths (for volk, fftw, talloc)
+if (EXISTS "/opt/homebrew/include")
+    target_include_directories(${PROJECT_NAME} PRIVATE "/opt/homebrew/include")
+endif()
+
+# Set compile arguments
+target_compile_options(${PROJECT_NAME} PRIVATE ${SDRPP_MODULE_COMPILER_FLAGS})
+
+# Find and link talloc
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(TALLOC REQUIRED talloc)
+target_include_directories(${PROJECT_NAME} PRIVATE ${TALLOC_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${TALLOC_LIBRARIES})
+target_link_directories(${PROJECT_NAME} PRIVATE ${TALLOC_LIBRARY_DIRS})
+
+# Install directives (for macOS, install to user's Library)
+install(TARGETS ${PROJECT_NAME} DESTINATION lib/sdrpp/plugins)


### PR DESCRIPTION
Added a new job that generates `tetra_demodulator.dylib` for macOS and Apple Silicon.

Fixes #36 

The new action ran on my fork https://github.com/tovkal/sdrpp-tetra-demodulator/actions