### PR TITLE
Some fixes to patch ETSI TETRA download_and_patch.sh script

### DIFF
--- a/src/decoder/etsi_codec-patches/download_and_patch.sh
+++ b/src/decoder/etsi_codec-patches/download_and_patch.sh
@@ -2,7 +2,7 @@
 
 URL=https://www.etsi.org/deliver/etsi_en/300300_300399/30039502/01.03.01_60/en_30039502v010301p0.zip
 MD5_EXP=a8115fe68ef8f8cc466f4192572a1e3e
-LOCAL_FILE=etsi_tetra_codec.zip
+LOCAL_FILE=en_30039502v010301p0.zip
 
 PATCHDIR=`pwd`
 CODECDIR=`pwd`/../codec

--- a/src/decoder/etsi_codec-patches/download_and_patch.sh
+++ b/src/decoder/etsi_codec-patches/download_and_patch.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-URL=http://www.etsi.org/deliver/etsi_en/300300_300399/30039502/01.03.01_60/en_30039502v010301p0.zip
+URL=https://www.etsi.org/deliver/etsi_en/300300_300399/30039502/01.03.01_60/en_30039502v010301p0.zip
 MD5_EXP=a8115fe68ef8f8cc466f4192572a1e3e
 LOCAL_FILE=etsi_tetra_codec.zip
 
@@ -24,7 +24,7 @@ MD5=`md5sum $LOCAL_FILE | awk '{ print $1 }'`
 
 echo Checking MD5SUM ...
 if [ $MD5 != $MD5_EXP ]; then
-	print "MD5sum of ETSI reference codec file doesn't match"
+	echo "MD5sum of ETSI reference codec file doesn't match"
 	exit 1
 fi
 
@@ -34,12 +34,24 @@ unzip -L $PATCHDIR/etsi_tetra_codec.zip
 echo Contents of $CODECDIR:
 ls -lah
 
+echo Fixing filenames...
+cd "$CODECDIR/c-code"
+
+for f in *; do
+    new="$(echo "$f" | tr 'I' 'i')"
+    if [ "$f" != "$new" ]; then
+        mv -i -- "$f" "$new"
+    fi
+done
+
+cd $CODECDIR
+
 echo Applying Patches ...
 ls -lah $PATCHDIR
 cat $PATCHDIR/series
 for p in `cat "$PATCHDIR/series"`; do
 	echo "=> Applying patch '$PATCHDIR/$p'..."
-	patch -p1 < "$PATCHDIR/$p"
+	patch -p1 -d "$CODECDIR" < "$PATCHDIR/$p"
 done
 
 echo Done!


### PR DESCRIPTION
Minor fixes inside the download_and_patch.sh have been fixed.

- Inside the ETSI zip, the c-code folder has filenames that have a capital "I" instead of the normal "i" on all files
- print replaced with echo
- https added because sometimes it just puts HTML code into the zip
- Patch command is fixed, so no more file issues

Note: This might fix build errors and AUR installation because it seems I can't install from AUR, solely by this script.