### PR TITLE
Fix HackRF crash-on-lock: heap-buffer-overflows in TETRA decoder

### DIFF
--- a/src/decoder/src/phy/tetra_burst.c
+++ b/src/decoder/src/phy/tetra_burst.c
@@ -292,7 +292,11 @@ int tetra_find_train_seq(const uint8_t *in, unsigned int end_of_in,
 
 	const uint8_t *cur;
 
-	for (cur = in; cur < in + end_of_in; cur++) {
+	/* each iteration reads cur[FILTER_LOOKAHEAD_LEN-1], so stop early enough
+	 * that this lookahead never reads past in[end_of_in-1] -- otherwise we
+	 * run off the end of bitbuf[] into the rest of the struct and beyond
+	 * (heap-buffer-overflow caught by ASan; corrupts burst_cb_priv). */
+	for (cur = in; cur + (FILTER_LOOKAHEAD_LEN-1) < in + end_of_in; cur++) {
 		filter = ((filter << 1) | cur[FILTER_LOOKAHEAD_LEN-1]) & FILTER_LOOKAHEAD_MASK;
 
 		int match = 0;
@@ -345,7 +349,8 @@ void tetra_burst_rx_cb(const uint8_t *burst, unsigned int len, enum tetra_train_
 	uint8_t bbk_buf[NDB_BBK_BITS];
 	uint8_t ndbf_buf[2*NDB_BLK_BITS];
 	struct tetra_mac_state *tms = priv;
-	
+
+	if (!tms || !tms->t_display_st) return; /* decoder state not ready yet */
 	tms->t_display_st->curr_multiframe = t_phy_state.time.mn;
 	tms->t_display_st->curr_frame = t_phy_state.time.fn;
 

--- a/src/decoder/src/phy/tetra_burst_sync.c
+++ b/src/decoder/src/phy/tetra_burst_sync.c
@@ -37,16 +37,26 @@ void tetra_burst_rx_cb(const uint8_t *burst, unsigned int len, enum tetra_train_
 
 static void make_bitbuf_space(struct tetra_rx_state *trs, unsigned int len)
 {
-	unsigned int bitbuf_space = sizeof(trs->bitbuf) - trs->bits_in_buf;
+	unsigned int bitbuf_space;
+
+	/* defensive: if the accounting ever goes out of range, an unsigned
+	 * underflow below would make us skip the shift and let the caller's
+	 * memcpy write past bitbuf[] into the following struct fields
+	 * (e.g. burst_cb_priv). Reset rather than corrupt memory. */
+	if (trs->bits_in_buf > sizeof(trs->bitbuf))
+		trs->bits_in_buf = 0;
+
+	bitbuf_space = sizeof(trs->bitbuf) - trs->bits_in_buf;
 
 	if (bitbuf_space < len) {
 		unsigned int delta = len - bitbuf_space;
+		if (delta > trs->bits_in_buf)
+			delta = trs->bits_in_buf;
 
 		DEBUGP("bitbuf left: %u, shrinking by %u\n", bitbuf_space, delta);
 		memmove(trs->bitbuf, trs->bitbuf + delta, trs->bits_in_buf - delta);
 		trs->bits_in_buf -= delta;
 		trs->bitbuf_start_bitnum += delta;
-		bitbuf_space = sizeof(trs->bitbuf) - trs->bits_in_buf;
 	}
 }
 
@@ -59,6 +69,11 @@ int tetra_burst_sync_in(struct tetra_rx_state *trs, uint8_t *bits, unsigned int 
 	DEBUGP("burst_sync_in: %u bits, state %u\n", len, trs->state);
 
 	/* First: append the data to the bitbuf */
+	if (len > sizeof(trs->bitbuf)) {
+		/* never accept more than the buffer can hold; keep newest bits */
+		bits += len - sizeof(trs->bitbuf);
+		len = sizeof(trs->bitbuf);
+	}
 	make_bitbuf_space(trs, len);
 	memcpy(trs->bitbuf + trs->bits_in_buf, bits, len);
 	trs->bits_in_buf += len;
@@ -96,6 +111,17 @@ int tetra_burst_sync_in(struct tetra_rx_state *trs, uint8_t *bits, unsigned int 
 			/* shift start of frame to start of bitbuf */
 			int offset = trs->next_frame_start_bitnum - trs->bitbuf_start_bitnum;
 			int bits_remaining = trs->bits_in_buf - offset;
+
+			/* guard against inconsistent bit accounting: a negative offset
+			 * (or out-of-range remainder) would make the memmove below read/
+			 * write past bitbuf[]. Resync from scratch instead. */
+			if (offset < 0 || bits_remaining < 0 ||
+			    (unsigned int)bits_remaining > sizeof(trs->bitbuf)) {
+				trs->state = RX_S_UNLOCKED;
+				trs->bitbuf_start_bitnum += trs->bits_in_buf;
+				trs->bits_in_buf = 0;
+				return len;
+			}
 
 			memmove(trs->bitbuf, trs->bitbuf+offset, bits_remaining);
 			trs->bits_in_buf = bits_remaining;

--- a/src/dsp/complex_fd.cpp
+++ b/src/dsp/complex_fd.cpp
@@ -93,6 +93,19 @@ namespace dsp {
             // Process all samples
             int outCount = 0;
             while (offset < count) {
+                // The clock-recovery PLL can diverge on noisy input (notably
+                // HackRF's 8-bit samples): a negative 'offset' makes the VOLK
+                // dot product below read before buffer[] (SIGSEGV, upstream
+                // issue #31), and a stalled 'offset' lets this loop overrun
+                // out[] -> heap corruption that trashes the decoder state
+                // (corrupted burst_cb_priv). Detect divergence and resync
+                // instead of indexing out of bounds.
+                if (offset < 0 || outCount >= STREAM_BUFFER_SIZE) {
+                    pcl.phase = 0.0f;
+                    pcl.freq = _omega;
+                    offset = count; // exit loop cleanly; offset -= count below -> 0
+                    break;
+                }
                 float error;
                 complex_t outVal;
                 complex_t dfdt;

--- a/src/dsp/osmotetra_dec.h
+++ b/src/dsp/osmotetra_dec.h
@@ -181,7 +181,13 @@ namespace dsp {
 
         inline int process(int count, const uint8_t* in, float* out)  {
             int outcnt = 0;
-            tetra_burst_sync_in(trs, (uint8_t*)in, count);
+            /* tetra_burst_sync_in()/make_bitbuf_space() corrupt the trs struct
+             * (overflowing bitbuf[4096] into burst_cb_priv) when fed more bits
+             * than the bitbuf can hold, so feed it in safe-sized chunks. */
+            const int CHUNK = 2048;
+            for (int off = 0; off < count; off += CHUNK) {
+                tetra_burst_sync_in(trs, (uint8_t*)in + off, std::min(CHUNK, count - off));
+            }
             if(out_tmp_buff.getReadable(false) > 0) {
                 outcnt += out_tmp_buff.read(out, out_tmp_buff.getReadable(false));
             }


### PR DESCRIPTION
The demodulator crashed (SIGSEGV) the moment it locked onto a signal when fed by a HackRF, while lower-rate SDRs worked fine (upstream issue #31). AddressSanitizer traced it to several heap-buffer-overflows in the sync / bit-accounting path, which only manifest once bitbuf[] fills up while hunting for sync in HackRF's noisier input.

Fixes:
- tetra_find_train_seq(): the scan reads cur[FILTER_LOOKAHEAD_LEN-1] each iteration but the loop bound did not account for that lookahead, reading up to 20 bytes past the search buffer. Stop the loop early enough that the lookahead stays in bounds.
- tetra_burst_sync_in() RX_S_KNOW_FSTART: a negative/inconsistent 'offset' produced a bits_remaining larger than the buffer, overflowing the memmove. Validate offset/bits_remaining and resync on inconsistency.
- make_bitbuf_space(): guard the unsigned underflow when bits_in_buf exceeds the buffer, clamp the shift delta, and clamp oversized input chunks so the append memcpy can never write past bitbuf[].
- osmotetra_dec.h process(): feed the synchronizer in <=2048-bit chunks.
- complex_fd.cpp clock recovery: bound the output index and resync if the PLL diverges, so it cannot read before buffer[] or overrun out[].

Found and verified with AddressSanitizer (clean through lock+decode+voice).

Fixes cropinghigh/sdrpp-tetra-demodulator#31